### PR TITLE
Boot time optimization

### DIFF
--- a/patches-aosp/glodroid/bootloader/u-boot/0005-rpi4-Remove-preboot-commands.patch
+++ b/patches-aosp/glodroid/bootloader/u-boot/0005-rpi4-Remove-preboot-commands.patch
@@ -1,0 +1,31 @@
+From a15187b6f31af4cfae328ffdd6b8c3baf559e755 Mon Sep 17 00:00:00 2001
+From: Roman Stratiienko <r.stratiienko@gmail.com>
+Date: Tue, 4 Apr 2023 23:32:38 +0300
+Subject: [PATCH] rpi4: Remove preboot commands
+
+With recent uboot it causes "Unexpected XHCI event TRB, skipping"
+error and continuous reboot.
+
+Also it affects boot time.
+
+Signed-off-by: Roman Stratiienko <r.stratiienko@gmail.com>
+---
+ configs/rpi_4_defconfig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configs/rpi_4_defconfig b/configs/rpi_4_defconfig
+index a6fe2feab2..5008ee3509 100644
+--- a/configs/rpi_4_defconfig
++++ b/configs/rpi_4_defconfig
+@@ -11,7 +11,7 @@ CONFIG_HAS_CUSTOM_SYS_INIT_SP_ADDR=y
+ CONFIG_CUSTOM_SYS_INIT_SP_ADDR=0x7fffe30
+ CONFIG_OF_BOARD_SETUP=y
+ CONFIG_USE_PREBOOT=y
+-CONFIG_PREBOOT="pci enum; usb start;"
++CONFIG_PREBOOT=""
+ # CONFIG_DISPLAY_CPUINFO is not set
+ # CONFIG_DISPLAY_BOARDINFO is not set
+ CONFIG_MISC_INIT_R=y
+-- 
+2.37.2
+

--- a/patches-aosp/glodroid/bootloader/u-boot/0006-GLODROID-Speed-up-boot.patch
+++ b/patches-aosp/glodroid/bootloader/u-boot/0006-GLODROID-Speed-up-boot.patch
@@ -1,0 +1,22 @@
+From 9b853aa8421d1c5e452d9eb6982fd36fc7dec8c9 Mon Sep 17 00:00:00 2001
+From: Roman Stratiienko <r.stratiienko@gmail.com>
+Date: Tue, 4 Apr 2023 21:48:18 +0300
+Subject: [PATCH] GLODROID: Speed-up boot
+
+Signed-off-by: Roman Stratiienko <r.stratiienko@gmail.com>
+---
+ configs/rpi_4_defconfig | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/configs/rpi_4_defconfig b/configs/rpi_4_defconfig
+index a6fe2feab2..c8968e24e6 100644
+--- a/configs/rpi_4_defconfig
++++ b/configs/rpi_4_defconfig
+@@ -65,3 +65,4 @@ CONFIG_VIDEO_BCM2835=y
+ CONFIG_CONSOLE_SCROLL_LINES=10
+ CONFIG_PHYS_TO_BUS=y
+ CONFIG_OF_LIBFDT_OVERLAY=y
++CONFIG_BOOTDELAY=0
+-- 
+2.37.2
+

--- a/patches-aosp/glodroid/configuration/0002-base-Don-t-use-updatable-apexes.patch
+++ b/patches-aosp/glodroid/configuration/0002-base-Don-t-use-updatable-apexes.patch
@@ -1,0 +1,29 @@
+From e35033902398d4e433e7694c11a17db7f44a7243 Mon Sep 17 00:00:00 2001
+From: Roman Stratiienko <r.stratiienko@gmail.com>
+Date: Tue, 4 Apr 2023 22:01:28 +0300
+Subject: [PATCH 2/5] base: Don't use updatable apexes
+
+This is useless for us but consumes some boot time.
+
+Signed-off-by: Roman Stratiienko <r.stratiienko@gmail.com>
+---
+ common/base/device.mk | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/common/base/device.mk b/common/base/device.mk
+index d69a8ef..98b9788 100644
+--- a/common/base/device.mk
++++ b/common/base/device.mk
+@@ -18,9 +18,6 @@ ifneq ($(filter $(TARGET_ARCH),arm64 x86_64),)
+     $(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)
+ endif
+ 
+-# Enable updating of APEXes
+-$(call inherit-product, $(SRC_TARGET_DIR)/product/updatable_apex.mk)
+-
+ # Enable userspace reboot
+ $(call inherit-product, $(SRC_TARGET_DIR)/product/userspace_reboot.mk)
+ 
+-- 
+2.37.2
+

--- a/patches-aosp/glodroid/configuration/0003-bootscript-Disable-uart-logging.patch
+++ b/patches-aosp/glodroid/configuration/0003-bootscript-Disable-uart-logging.patch
@@ -1,0 +1,28 @@
+From 4391fb36ce55370ac46fbe30008049a17189dd22 Mon Sep 17 00:00:00 2001
+From: Roman Stratiienko <r.stratiienko@gmail.com>
+Date: Tue, 4 Apr 2023 22:06:44 +0300
+Subject: [PATCH 4/5] bootscript: Disable uart logging
+
+Improves boot time significantly.
+
+Signed-off-by: Roman Stratiienko <r.stratiienko@gmail.com>
+---
+ platform/uboot/bootscript.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/platform/uboot/bootscript.cpp b/platform/uboot/bootscript.cpp
+index e9da6a4..36f69c1 100644
+--- a/platform/uboot/bootscript.cpp
++++ b/platform/uboot/bootscript.cpp
+@@ -46,7 +46,7 @@ EXTENV(partitions, ";name=userdata,size=-,uuid=\${uuid_gpt_userdata}")
+ setenv bootargs " init=/init rootwait ro androidboot.boottime=223.708 androidboot.selinux=permissive"
+ EXTENV(bootargs, " androidboot.revision=1.0 androidboot.board_id=0x1234567 androidboot.serialno=${serial#}")
+ EXTENV(bootargs, " firmware_class.path=/vendor/etc/firmware")
+-EXTENV(bootargs, " ${debug_bootargs} printk.devkmsg=on")
++EXTENV(bootargs, " ${debug_bootargs} printk.devkmsg=on quiet")
+ 
+ FUNC_BEGIN(enter_fastboot)
+ #ifdef PRE_ENTER_FASTBOOT
+-- 
+2.37.2
+

--- a/patches-aosp/glodroid/configuration/0004-Disable-AVB.patch
+++ b/patches-aosp/glodroid/configuration/0004-Disable-AVB.patch
@@ -1,0 +1,56 @@
+From 27575d5205e12031f35b99e8be1f58b3334e59d5 Mon Sep 17 00:00:00 2001
+From: Roman Stratiienko <r.stratiienko@gmail.com>
+Date: Tue, 4 Apr 2023 22:07:21 +0300
+Subject: [PATCH 4/4] Disable AVB
+
+Reduces boot time.
+
+Signed-off-by: Roman Stratiienko <r.stratiienko@gmail.com>
+---
+ platform/fstab/fstab.cpp      | 10 +++++-----
+ platform/uboot/bootscript.cpp |  8 +-------
+ 2 files changed, 6 insertions(+), 12 deletions(-)
+
+diff --git a/platform/fstab/fstab.cpp b/platform/fstab/fstab.cpp
+index a514344..722b70f 100644
+--- a/platform/fstab/fstab.cpp
++++ b/platform/fstab/fstab.cpp
+@@ -11,11 +11,11 @@
+ #define __FILE_ENCRYPT__ fileencryption=aes-256-xts:aes-256-cts
+ #endif
+ 
+-system                              /system         ext4    ro,barrier=1                          wait,first_stage_mount,logical,slotselect,avb=vbmeta_system,avb_keys=/avb
+-system_ext                          /system_ext     ext4    ro,barrier=1                          wait,first_stage_mount,logical,slotselect,avb=vbmeta_system
+-product                             /product        ext4    ro,barrier=1                          wait,first_stage_mount,logical,slotselect,avb=vbmeta_system
+-vendor                              /vendor         ext4    ro,barrier=1                          wait,first_stage_mount,logical,slotselect,avb=vbmeta
+-vendor_dlkm                         /vendor_dlkm    ext4    ro,noatime,errors=panic               wait,first_stage_mount,logical,slotselect,avb=vbmeta
++system                              /system         ext4    ro,barrier=1                          wait,first_stage_mount,logical,slotselect
++system_ext                          /system_ext     ext4    ro,barrier=1                          wait,first_stage_mount,logical,slotselect
++product                             /product        ext4    ro,barrier=1                          wait,first_stage_mount,logical,slotselect
++vendor                              /vendor         ext4    ro,barrier=1                          wait,first_stage_mount,logical,slotselect
++vendor_dlkm                         /vendor_dlkm    ext4    ro,noatime,errors=panic               wait,first_stage_mount,logical,slotselect
+ 
+ /dev/block/by-name/misc             /misc           emmc    defaults                              defaults
+ 
+diff --git a/platform/uboot/bootscript.cpp b/platform/uboot/bootscript.cpp
+index e9da6a4..b07bcbb 100644
+--- a/platform/uboot/bootscript.cpp
++++ b/platform/uboot/bootscript.cpp
+@@ -147,13 +147,7 @@ FUNC_BEGIN(bootcmd_block)
+  DEVICE_HANDLE_BUTTONS()
+ #endif
+  run bootcmd_bcb
+- if test STRESC(\$androidrecovery) = STRESC("true");
+- then
+-  /* Always unlock device for fastbootd and recovery modes, otherwise fastbootd flashing won't work. TODO: Support conditional lock/unlock */
+-  EXTENV(bootargs, " androidboot.verifiedbootstate=orange ");
+- else
+-  run bootcmd_avb;
+- fi;
++ EXTENV(bootargs, " androidboot.verifiedbootstate=orange ");
+ 
+  part start mmc \$mmc_bootdev boot_\$slot_name boot_start &&
+  part size  mmc \$mmc_bootdev boot_\$slot_name boot_size
+-- 
+2.37.2
+


### PR DESCRIPTION
Baseline 1m42s

Quiet the serial console = 1m24s (-18s)
Disable updatable apexes = 1m11s (-13s)
Remove uboot countdown = 1m9s (-2s)
Remove AVB = 0m56s (-13s)