### PR TITLE
Add v4l2_codec2 and ffmpeg_codec2

### DIFF
--- a/aosptree/vendor/devices-community/gd_rpi4/boot/config.txt
+++ b/aosptree/vendor/devices-community/gd_rpi4/boot/config.txt
@@ -19,3 +19,6 @@ max_framebuffers=2
 
 # Automatically load overlays for detected DSI displays
 display_auto_detect=1
+
+dtoverlay=cma,cma-512
+dtoverlay=rpivid-v4l2

--- a/aosptree/vendor/devices-community/gd_rpi4/device.mk
+++ b/aosptree/vendor/devices-community/gd_rpi4/device.mk
@@ -56,3 +56,6 @@ PRODUCT_VENDOR_PROPERTIES +=    \
 
 # It is the only way to set ro.hwui.use_vulkan=true
 #TARGET_USES_VULKAN = true
+
+PRODUCT_PROPERTY_OVERRIDES += \
+    vendor.gralloc.minigbm.backend=gbm_mesa \

--- a/manifests/glodroid.xml
+++ b/manifests/glodroid.xml
@@ -6,6 +6,7 @@
   <remote  name="mbroadband" fetch="https://gitlab.freedesktop.org/mobile-broadband" />
   <remote  name="dbus"       fetch="https://gitlab.freedesktop.org/dbus" />
   <remote  name="libcamera"  fetch="https://git.libcamera.org/libcamera" />
+  <remote  name="raspberry-vanilla" fetch="https://github.com/raspberry-vanilla/" />
 
   <remove-project name="platform/external/mesa3d" />
   <remove-project name="platform/external/drm_hwcomposer" />
@@ -24,6 +25,11 @@
   <project path="glodroid/vendor/libcamera"                     remote="libcamera" name="libcamera.git"      groups="glodroid" revision="ea8ae5afff226f9373c82c1a3185e532d5d6eda0" />
   <project path="glodroid/vendor/libcamera/subprojects/libyuv"  remote="glodroid"  name="glodroid_forks.git" groups="glodroid" revision="refs/tags/libyuv-v0.8.2" />
   <project path="glodroid/vendor/libcamera/subprojects/libyaml" remote="github"    name="yaml/libyaml.git"   groups="glodroid" revision="refs/tags/0.2.5" />
+
+  <!-- FFmpeg -->
+  <project path="external/dav1d" name="android_external_dav1d.git" remote="raspberry-vanilla" revision="android-13.0" />
+  <project path="external/ffmpeg" name="android_external_ffmpeg.git" remote="raspberry-vanilla" revision="android-13.0" />
+  <project path="external/ffmpeg_codec2" name="android_external_ffmpeg_codec2.git" remote="raspberry-vanilla" revision="android-13.0" />
 
   <!-- modem components (vendor) -->
   <project path="glodroid/vendor/mm-radio"        remote="glodroid"    name="mm-radio.git"     groups="glodroid" revision="90f9f9a8b20ce2e153d39c9fc250ab2733a7fbb9" />

--- a/patches-aosp/external/v4l2_codec2/0001-v4l2-WIP-codecs-for-rpi4.patch
+++ b/patches-aosp/external/v4l2_codec2/0001-v4l2-WIP-codecs-for-rpi4.patch
@@ -1,0 +1,385 @@
+From 0c0e0baf62a222abbbe422019ca109153185775c Mon Sep 17 00:00:00 2001
+From: Roman Stratiienko <r.stratiienko@gmail.com>
+Date: Sat, 8 Oct 2022 20:02:20 +0300
+Subject: [PATCH] v4l2: WIP codecs for rpi4
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Roman Stratiienko <r.stratiienko@gmail.com>
+Change-Id: Idb6499ce47d4e2f585eb8fd84795ae95a315d5a7
+Signed-off-by: Michał Gapiński <mike@gapinski.eu>
+---
+ common/Fourcc.cpp                             |  9 +++++
+ common/VideoPixelFormat.cpp                   |  7 ++++
+ common/include/v4l2_codec2/common/Fourcc.h    |  2 ++
+ .../v4l2_codec2/common/VideoPixelFormat.h     |  1 +
+ components/V4L2Decoder.cpp                    | 13 +++++---
+ components/V4L2EncodeComponent.cpp            | 33 ++++++++++---------
+ components/V4L2EncodeInterface.cpp            | 15 +++------
+ components/V4L2Encoder.cpp                    | 11 ++++---
+ plugin_store/Android.bp                       |  2 +-
+ plugin_store/C2VdaBqBlockPool.cpp             |  1 +
+ 10 files changed, 58 insertions(+), 36 deletions(-)
+
+diff --git a/common/Fourcc.cpp b/common/Fourcc.cpp
+index 11ea31e..7ff9249 100644
+--- a/common/Fourcc.cpp
++++ b/common/Fourcc.cpp
+@@ -25,6 +25,7 @@ std::optional<Fourcc> Fourcc::fromUint32(uint32_t fourcc) {
+     case XR24:
+     case XB24:
+     case RGB4:
++    case BGR4:
+     case YU12:
+     case YV12:
+     case YM12:
+@@ -58,6 +59,8 @@ std::optional<Fourcc> Fourcc::fromVideoPixelFormat(VideoPixelFormat pixelFormat,
+             return Fourcc(XB24);
+         case VideoPixelFormat::BGRA:
+             return Fourcc(RGB4);
++        case VideoPixelFormat::RGBA:
++            return Fourcc(BGR4);
+         case VideoPixelFormat::I420:
+             return Fourcc(YU12);
+         case VideoPixelFormat::YV12:
+@@ -124,6 +127,7 @@ std::optional<Fourcc> Fourcc::fromVideoPixelFormat(VideoPixelFormat pixelFormat,
+         case VideoPixelFormat::XR30:
+         case VideoPixelFormat::XB30:
+         case VideoPixelFormat::BGRA:
++        case VideoPixelFormat::RGBA:
+         case VideoPixelFormat::UNKNOWN:
+             break;
+         }
+@@ -145,6 +149,8 @@ VideoPixelFormat Fourcc::toVideoPixelFormat() const {
+         return VideoPixelFormat::XBGR;
+     case RGB4:
+         return VideoPixelFormat::BGRA;
++    case BGR4:
++        return VideoPixelFormat::RGBA;
+     case YU12:
+     case YM12:
+         return VideoPixelFormat::I420;
+@@ -200,6 +206,7 @@ std::optional<Fourcc> Fourcc::toSinglePlanar() const {
+     case XR24:
+     case XB24:
+     case RGB4:
++    case BGR4:
+     case YU12:
+     case YV12:
+     case YUYV:
+@@ -232,6 +239,7 @@ bool Fourcc::isMultiPlanar() const {
+     case XR24:
+     case XB24:
+     case RGB4:
++    case BGR4:
+     case YU12:
+     case YV12:
+     case YUYV:
+@@ -264,6 +272,7 @@ static_assert(Fourcc::XR24 == V4L2_PIX_FMT_XBGR32, "Mismatch Fourcc");
+ static_assert(Fourcc::XB24 == V4L2_PIX_FMT_RGBX32, "Mismatch Fourcc");
+ #endif  // V4L2_PIX_FMT_RGBX32
+ static_assert(Fourcc::RGB4 == V4L2_PIX_FMT_RGB32, "Mismatch Fourcc");
++static_assert(Fourcc::BGR4 == V4L2_PIX_FMT_BGR32, "Mismatch Fourcc");
+ static_assert(Fourcc::YU12 == V4L2_PIX_FMT_YUV420, "Mismatch Fourcc");
+ static_assert(Fourcc::YV12 == V4L2_PIX_FMT_YVU420, "Mismatch Fourcc");
+ static_assert(Fourcc::YM12 == V4L2_PIX_FMT_YUV420M, "Mismatch Fourcc");
+diff --git a/common/VideoPixelFormat.cpp b/common/VideoPixelFormat.cpp
+index f175c26..661a5d8 100644
+--- a/common/VideoPixelFormat.cpp
++++ b/common/VideoPixelFormat.cpp
+@@ -82,6 +82,8 @@ std::string videoPixelFormatToString(VideoPixelFormat format) {
+         return "XB30";
+     case VideoPixelFormat::BGRA:
+         return "BGRA";
++    case VideoPixelFormat::RGBA:
++        return "BGRA";
+     case VideoPixelFormat::UNKNOWN:
+         return "UNKNOWN";
+     }
+@@ -116,6 +118,7 @@ size_t bitDepth(VideoPixelFormat format) {
+     case VideoPixelFormat::ABGR:
+     case VideoPixelFormat::XBGR:
+     case VideoPixelFormat::BGRA:
++    case VideoPixelFormat::RGBA:
+         return 8;
+     case VideoPixelFormat::YUV420P9:
+     case VideoPixelFormat::YUV422P9:
+@@ -153,6 +156,7 @@ static bool RequiresEvenSizeAllocation(VideoPixelFormat format) {
+     case VideoPixelFormat::XR30:
+     case VideoPixelFormat::XB30:
+     case VideoPixelFormat::BGRA:
++    case VideoPixelFormat::RGBA:
+         return false;
+     case VideoPixelFormat::NV12:
+     case VideoPixelFormat::NV21:
+@@ -185,6 +189,7 @@ size_t numPlanes(VideoPixelFormat format) {
+     case VideoPixelFormat::YUY2:
+     case VideoPixelFormat::ARGB:
+     case VideoPixelFormat::BGRA:
++    case VideoPixelFormat::RGBA:
+     case VideoPixelFormat::XRGB:
+     case VideoPixelFormat::RGB24:
+     case VideoPixelFormat::MJPEG:
+@@ -269,6 +274,7 @@ int bytesPerElement(VideoPixelFormat format, size_t plane) {
+     switch (format) {
+     case VideoPixelFormat::ARGB:
+     case VideoPixelFormat::BGRA:
++    case VideoPixelFormat::RGBA:
+     case VideoPixelFormat::XRGB:
+     case VideoPixelFormat::ABGR:
+     case VideoPixelFormat::XBGR:
+@@ -361,6 +367,7 @@ android::ui::Size SampleSize(VideoPixelFormat format, size_t plane) {
+         case VideoPixelFormat::XR30:
+         case VideoPixelFormat::XB30:
+         case VideoPixelFormat::BGRA:
++        case VideoPixelFormat::RGBA:
+             ALOGE("Invalid pixel format");
+         }
+     }
+diff --git a/common/include/v4l2_codec2/common/Fourcc.h b/common/include/v4l2_codec2/common/Fourcc.h
+index a0f5fc4..972a4a3 100644
+--- a/common/include/v4l2_codec2/common/Fourcc.h
++++ b/common/include/v4l2_codec2/common/Fourcc.h
+@@ -54,6 +54,8 @@ class Fourcc {
+         // it as-is.
+         RGB4 = composeFourcc('R', 'G', 'B', '4'),
+ 
++        BGR4 = composeFourcc('B', 'G', 'R', '4'),
++
+         // YUV420 single-planar formats.
+         // https://linuxtv.org/downloads/v4l-dvb-apis/uapi/v4l/pixfmt-yuv420.html
+         // Maps to PIXEL_FORMAT_I420, V4L2_PIX_FMT_YUV420, VA_FOURCC_I420.
+diff --git a/common/include/v4l2_codec2/common/VideoPixelFormat.h b/common/include/v4l2_codec2/common/VideoPixelFormat.h
+index 2cfe910..9867c79 100644
+--- a/common/include/v4l2_codec2/common/VideoPixelFormat.h
++++ b/common/include/v4l2_codec2/common/VideoPixelFormat.h
+@@ -35,6 +35,7 @@ enum class VideoPixelFormat {
+     XR30,    // 32bpp BGRX, 10 bits per channel, 2 bits ignored, 1 plane
+     XB30,    // 32bpp RGBX, 10 bits per channel, 2 bits ignored, 1 plane
+     BGRA,    // 32bpp ARGB (byte-order), 1 plane.
++    RGBA,    // 32bpp ABGR (byte-order), 1 plane.
+     // The P* in the formats below designates the number of bits per pixel component. I.e. P9 is
+     // 9-bits per pixel component, P10 is 10-bits per pixel component, etc.
+     YUV420P9,
+diff --git a/components/V4L2Decoder.cpp b/components/V4L2Decoder.cpp
+index aa59e91..d7d8b55 100644
+--- a/components/V4L2Decoder.cpp
++++ b/components/V4L2Decoder.cpp
+@@ -23,15 +23,14 @@
+ namespace android {
+ namespace {
+ 
+-constexpr size_t kNumInputBuffers = 16;
++constexpr size_t kNumInputBuffers = 4;
+ // Extra buffers for transmitting in the whole video pipeline.
+ constexpr size_t kNumExtraOutputBuffers = 4;
+ 
+ // Currently we only support flexible pixel 420 format YCBCR_420_888 in Android.
+ // Here is the list of flexible 420 format.
+ constexpr std::initializer_list<uint32_t> kSupportedOutputFourccs = {
+-        Fourcc::YU12, Fourcc::YV12, Fourcc::YM12, Fourcc::YM21,
+-        Fourcc::NV12, Fourcc::NV21, Fourcc::NM12, Fourcc::NM21,
++        Fourcc::NV12,
+ };
+ 
+ uint32_t VideoCodecToV4L2PixFmt(VideoCodec codec) {
+@@ -94,7 +93,7 @@ V4L2Decoder::~V4L2Decoder() {
+ bool V4L2Decoder::start(const VideoCodec& codec, const size_t inputBufferSize,
+                         const size_t minNumOutputBuffers, GetPoolCB getPoolCb, OutputCB outputCb,
+                         ErrorCB errorCb) {
+-    ALOGV("%s(codec=%s, inputBufferSize=%zu, minNumOutputBuffers=%zu)", __func__,
++    ALOGE("%s(codec=%s, inputBufferSize=%zu, minNumOutputBuffers=%zu)", __func__,
+           VideoCodecToString(codec), inputBufferSize, minNumOutputBuffers);
+     ALOG_ASSERT(mTaskRunner->RunsTasksInCurrentSequence());
+ 
+@@ -557,6 +556,11 @@ bool V4L2Decoder::changeResolution() {
+ }
+ 
+ bool V4L2Decoder::setupOutputFormat(const ui::Size& size) {
++    for (const uint32_t& pixfmt :
++         mDevice->enumerateSupportedPixelformats(V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE)) {
++        ALOGV("Available pixel format %s", fourccToString(pixfmt).c_str());
++    }
++
+     for (const uint32_t& pixfmt :
+          mDevice->enumerateSupportedPixelformats(V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE)) {
+         if (std::find(kSupportedOutputFourccs.begin(), kSupportedOutputFourccs.end(), pixfmt) ==
+@@ -566,6 +570,7 @@ bool V4L2Decoder::setupOutputFormat(const ui::Size& size) {
+         }
+ 
+         if (mOutputQueue->setFormat(pixfmt, size, 0) != std::nullopt) {
++        ALOGV("Set pixel format %s", fourccToString(pixfmt).c_str());
+             return true;
+         }
+     }
+diff --git a/components/V4L2EncodeComponent.cpp b/components/V4L2EncodeComponent.cpp
+index c2a2679..8cb88cd 100644
+--- a/components/V4L2EncodeComponent.cpp
++++ b/components/V4L2EncodeComponent.cpp
+@@ -643,6 +643,8 @@ bool V4L2EncodeComponent::initializeEncoder() {
+     // the V4L2 encoder.
+     std::optional<uint32_t> stride =
+             getVideoFrameStride(kInputPixelFormat, mInterface->getInputVisibleSize());
++
++    stride = 32;
+     if (!stride) {
+         ALOGE("Failed to get video frame stride");
+         reportError(C2_CORRUPTED);
+@@ -677,7 +679,7 @@ bool V4L2EncodeComponent::initializeEncoder() {
+                                     V4L2Encoder::kInputBufferCount, mEncoder->codedSize());
+     if (!mInputFormatConverter) {
+         ALOGE("Failed to created input format convertor");
+-        return false;
++        //return false;
+     }
+ 
+     return true;
+@@ -691,7 +693,7 @@ bool V4L2EncodeComponent::updateEncodingParameters() {
+     // framework doesn't offer a parameter to configure the peak bitrate, so we'll use a multiple of
+     // the target bitrate here. The peak bitrate is only used if the bitrate mode is set to VBR.
+     uint32_t bitrate = mInterface->getBitrate();
+-    if (mBitrate != bitrate) {
++    //if (mBitrate != bitrate) {
+         ALOG_ASSERT(bitrate > 0u);
+         ALOGV("Setting bitrate to %u", bitrate);
+         if (!mEncoder->setBitrate(bitrate)) {
+@@ -706,20 +708,20 @@ bool V4L2EncodeComponent::updateEncodingParameters() {
+             // errors for now.
+             mEncoder->setPeakBitrate(bitrate * kPeakBitrateMultiplier);
+         }
+-    }
++    //}
+ 
+     // Ask device to change framerate if it's different from the currently configured framerate.
+-    uint32_t framerate = static_cast<uint32_t>(std::round(mInterface->getFramerate()));
+-    if (mFramerate != framerate) {
+-        ALOG_ASSERT(framerate > 0u);
+-        ALOGV("Setting framerate to %u", framerate);
+-        if (!mEncoder->setFramerate(framerate)) {
+-            ALOGE("Requesting framerate change failed");
+-            reportError(C2_CORRUPTED);
+-            return false;
+-        }
+-        mFramerate = framerate;
+-    }
++    //uint32_t framerate = static_cast<uint32_t>(std::round(mInterface->getFramerate()));
++    // if (mFramerate != framerate) {
++    //     ALOG_ASSERT(framerate > 0u);
++    //     ALOGV("Setting framerate to %u", framerate);
++    //     if (!mEncoder->setFramerate(framerate)) {
++    //         ALOGE("Requesting framerate change failed");
++    //         reportError(C2_CORRUPTED);
++    //         return false;
++    //     }
++    //     mFramerate = framerate;
++    // }
+ 
+     // Check whether an explicit key frame was requested, if so reset the key frame counter to
+     // immediately request a key frame.
+@@ -757,8 +759,7 @@ bool V4L2EncodeComponent::encode(C2ConstGraphicBlock block, uint64_t index, int6
+     constexpr int64_t kMaxFramerateDiff = 5;
+     if (mLastFrameTime && (timestamp > *mLastFrameTime)) {
+         int64_t newFramerate = std::max(
+-                static_cast<int64_t>(std::round(1000000.0 / (timestamp - *mLastFrameTime))),
+-                static_cast<int64_t>(1LL));
++                static_cast<int64_t>(std::round(1000000.0 / (timestamp - *mLastFrameTime))), static_cast<int64_t>(1));
+         if (abs(mFramerate - newFramerate) > kMaxFramerateDiff) {
+             ALOGV("Adjusting framerate to %" PRId64 " based on frame timestamps", newFramerate);
+             mInterface->setFramerate(static_cast<uint32_t>(newFramerate));
+diff --git a/components/V4L2EncodeInterface.cpp b/components/V4L2EncodeInterface.cpp
+index 03d8c37..314794f 100644
+--- a/components/V4L2EncodeInterface.cpp
++++ b/components/V4L2EncodeInterface.cpp
+@@ -382,17 +382,10 @@ void V4L2EncodeInterface::Initialize(const C2String& name) {
+                     .withConstValue(new C2StreamBufferTypeSetting::input(0u, C2BufferData::GRAPHIC))
+                     .build());
+ 
+-    // TODO(b/167640667) Add VIDEO_ENCODER flag once input convertor is not enabled by default.
+-    // When using the format convertor (which is currently always enabled) it's not useful to add
+-    // the VIDEO_ENCODER buffer flag for input buffers here. Currently zero-copy is not supported
+-    // yet, so when using this flag an additional buffer will be allocated on host side and a copy
+-    // will be performed between the guest and host buffer to keep them in sync. This is wasteful as
+-    // the buffer is only used on guest side by the format convertor which converts and copies the
+-    // buffer into another buffer.
+-    //addParameter(DefineParam(mInputMemoryUsage, C2_PARAMKEY_INPUT_STREAM_USAGE)
+-    //                     .withConstValue(new C2StreamUsageTuning::input(
+-    //                             0u, static_cast<uint64_t>(BufferUsage::VIDEO_ENCODER)))
+-    //                     .build());
++    addParameter(DefineParam(mInputMemoryUsage, C2_PARAMKEY_INPUT_STREAM_USAGE)
++                         .withConstValue(new C2StreamUsageTuning::input(
++                                 0u, static_cast<uint64_t>(BufferUsage::VIDEO_ENCODER)))
++                         .build());
+ 
+     addParameter(
+             DefineParam(mOutputFormat, C2_PARAMKEY_OUTPUT_STREAM_BUFFER_TYPE)
+diff --git a/components/V4L2Encoder.cpp b/components/V4L2Encoder.cpp
+index cd20cb5..67db9fd 100644
+--- a/components/V4L2Encoder.cpp
++++ b/components/V4L2Encoder.cpp
+@@ -26,6 +26,7 @@ namespace android {
+ 
+ namespace {
+ 
++//const VideoPixelFormat kInputPixelFormat = VideoPixelFormat::RGBA;
+ const VideoPixelFormat kInputPixelFormat = VideoPixelFormat::NV12;
+ 
+ // The maximum size for output buffer, which is chosen empirically for a 1080p video.
+@@ -463,7 +464,7 @@ bool V4L2Encoder::configureInputFormat(VideoPixelFormat inputFormat, uint32_t st
+ 
+     // First try to use the requested pixel format directly.
+     std::optional<struct v4l2_format> format;
+-    auto fourcc = Fourcc::fromVideoPixelFormat(inputFormat, false);
++    auto fourcc = Fourcc::fromVideoPixelFormat(inputFormat, true);
+     if (fourcc) {
+         format = mInputQueue->setFormat(fourcc->toV4L2PixFmt(), mVisibleSize, 0, stride);
+     }
+@@ -665,8 +666,8 @@ bool V4L2Encoder::configureBitrateMode(C2Config::bitrate_mode_t bitrateMode) {
+     ALOGV("%s()", __func__);
+     ALOG_ASSERT(mTaskRunner->RunsTasksInCurrentSequence());
+ 
+-    v4l2_mpeg_video_bitrate_mode v4l2BitrateMode =
+-            V4L2Device::C2BitrateModeToV4L2BitrateMode(bitrateMode);
++    v4l2_mpeg_video_bitrate_mode v4l2BitrateMode {};
++            //V4L2Device::C2BitrateModeToV4L2BitrateMode(bitrateMode);
+     if (!mDevice->setExtCtrls(V4L2_CTRL_CLASS_MPEG,
+                               {V4L2ExtCtrl(V4L2_CID_MPEG_VIDEO_BITRATE_MODE, v4l2BitrateMode)})) {
+         // TODO(b/190336806): Our stack doesn't support bitrate mode changes yet. We default to CBR
+@@ -737,9 +738,11 @@ bool V4L2Encoder::enqueueInputBuffer(std::unique_ptr<InputFrame> frame) {
+     ALOG_ASSERT(mInputQueue->freeBuffersCount() > 0);
+     ALOG_ASSERT(mState == State::ENCODING);
+     ALOG_ASSERT(frame);
+-    ALOG_ASSERT(mInputLayout->mFormat == frame->pixelFormat());
++//    ALOG_ASSERT(mInputLayout->mFormat == frame->pixelFormat());
+     ALOG_ASSERT(mInputLayout->mPlanes.size() == frame->planes().size());
+ 
++    ALOGI("InputLayout fmt: %s, FramePixFmt: %s", videoPixelFormatToString(mInputLayout->mFormat).c_str(), videoPixelFormatToString(frame->pixelFormat()).c_str());
++
+     auto format = frame->pixelFormat();
+     auto planes = frame->planes();
+     auto index = frame->index();
+diff --git a/plugin_store/Android.bp b/plugin_store/Android.bp
+index 621cbfc..ec44f13 100644
+--- a/plugin_store/Android.bp
++++ b/plugin_store/Android.bp
+@@ -9,7 +9,7 @@ package {
+ 
+ cc_library_shared {
+     name: "libc2plugin_store",
+-    vendor: true,
++    vendor_available: true,
+ 
+     defaults: [
+         "libcodec2-impl-defaults",
+diff --git a/plugin_store/C2VdaBqBlockPool.cpp b/plugin_store/C2VdaBqBlockPool.cpp
+index d53f4a0..2be0a0c 100644
+--- a/plugin_store/C2VdaBqBlockPool.cpp
++++ b/plugin_store/C2VdaBqBlockPool.cpp
+@@ -931,6 +931,7 @@ c2_status_t C2VdaBqBlockPool::requestNewBufferSet(int32_t bufferCount, uint32_t
+     if (mImpl) {
+         return mImpl->requestNewBufferSet(bufferCount, width, height, format, usage);
+     }
++    ALOGE("No init!!!");
+     return C2_NO_INIT;
+ }
+ 

--- a/patches-aosp/external/v4l2_codec2/0002-HACK-rpi4-force-NV12-pixel-format.patch
+++ b/patches-aosp/external/v4l2_codec2/0002-HACK-rpi4-force-NV12-pixel-format.patch
@@ -1,0 +1,29 @@
+From 9d63be45bd0fff14b15bb36043950c6331acca0b Mon Sep 17 00:00:00 2001
+From: Konsta <konsta09@gmail.com>
+Date: Sun, 8 Jan 2023 17:55:02 +0200
+Subject: [PATCH] HACK: rpi4: force NV12 pixel format
+
+* minigbm gralloc uses NV12 for flexible YCBCR_420_888
+
+Change-Id: Ifd71736c2d7e29732ea661b39293b2f2e404879f
+---
+ components/V4L2Decoder.cpp | 6 +-----
+ 1 file changed, 1 insertion(+), 5 deletions(-)
+
+diff --git a/components/V4L2Decoder.cpp b/components/V4L2Decoder.cpp
+index d7d8b55..9440135 100644
+--- a/components/V4L2Decoder.cpp
++++ b/components/V4L2Decoder.cpp
+@@ -558,11 +558,7 @@ bool V4L2Decoder::changeResolution() {
+ bool V4L2Decoder::setupOutputFormat(const ui::Size& size) {
+     for (const uint32_t& pixfmt :
+          mDevice->enumerateSupportedPixelformats(V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE)) {
+-        ALOGV("Available pixel format %s", fourccToString(pixfmt).c_str());
+-    }
+-
+-    for (const uint32_t& pixfmt :
+-         mDevice->enumerateSupportedPixelformats(V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE)) {
++        if (pixfmt != Fourcc::NV12) continue;
+         if (std::find(kSupportedOutputFourccs.begin(), kSupportedOutputFourccs.end(), pixfmt) ==
+             kSupportedOutputFourccs.end()) {
+             ALOGD("Pixel format %s is not supported, skipping...", fourccToString(pixfmt).c_str());

--- a/patches-aosp/external/v4l2_codec2/0003-add-vintf-fragment-and-rename-default-interface-to-v4l2.patch
+++ b/patches-aosp/external/v4l2_codec2/0003-add-vintf-fragment-and-rename-default-interface-to-v4l2.patch
@@ -1,0 +1,82 @@
+From 0526f56990c532c03998ee47f603919015cf85d5 Mon Sep 17 00:00:00 2001
+From: Konsta <konsta09@gmail.com>
+Date: Fri, 27 Jan 2023 20:59:25 +0200
+Subject: [PATCH] add vintf fragment and rename default interface to v4l2
+
+Change-Id: I2933e67526e1f7e499b73571555fffde91757073
+---
+ README.md                                     | 20 -------------------
+ service/Android.bp                            |  2 ++
+ ...oid.hardware.media.c2@1.0-service-v4l2.xml |  7 +++++++
+ service/service.cpp                           |  2 +-
+ 4 files changed, 10 insertions(+), 21 deletions(-)
+ create mode 100644 service/android.hardware.media.c2@1.0-service-v4l2.xml
+
+diff --git a/README.md b/README.md
+index aa59a40..7b4455d 100644
+--- a/README.md
++++ b/README.md
+@@ -74,26 +74,6 @@ PRODUCT_COPY_FILES += \
+     <path_to_policy>:$(TARGET_COPY_OUT_VENDOR)/etc/seccomp_policy/codec2.vendor.ext.policy
+ ```
+ 
+-Enable codec2 hidl in manifest.xml
+-
+-```xml
+-<manifest version="1.0" type="device">
+-    <hal format="hidl">
+-        <name>android.hardware.media.c2</name>
+-        <transport>hwbinder</transport>
+-        <version>1.0</version>
+-        <interface>
+-            <name>IComponentStore</name>
+-            <instance>default</instance>
+-        </interface>
+-        <interface>
+-            <name>IConfigurable</name>
+-            <instance>default</instance>
+-        </interface>
+-    </hal>
+-</manifest>
+-```
+-
+ Add decode and encode components in media\_codecs\_c2.xml
+ 
+ ```xml
+diff --git a/service/Android.bp b/service/Android.bp
+index c901a02..8c69ad8 100644
+--- a/service/Android.bp
++++ b/service/Android.bp
+@@ -44,4 +44,6 @@ cc_binary {
+             init_rc: ["android.hardware.media.c2@1.0-service-v4l2-64.rc"],
+         },
+     },
++
++    vintf_fragments: ["android.hardware.media.c2@1.0-service-v4l2.xml"],
+ }
+diff --git a/service/android.hardware.media.c2@1.0-service-v4l2.xml b/service/android.hardware.media.c2@1.0-service-v4l2.xml
+new file mode 100644
+index 0000000..c8a456b
+--- /dev/null
++++ b/service/android.hardware.media.c2@1.0-service-v4l2.xml
+@@ -0,0 +1,7 @@
++<manifest version="1.0" type="device">
++    <hal format="hidl">
++        <name>android.hardware.media.c2</name>
++        <transport>hwbinder</transport>
++        <fqname>@1.0::IComponentStore/v4l2</fqname>
++    </hal>
++</manifest>
+diff --git a/service/service.cpp b/service/service.cpp
+index 616e641..8c4089f 100644
+--- a/service/service.cpp
++++ b/service/service.cpp
+@@ -46,7 +46,7 @@ int main(int /* argc */, char** /* argv */) {
+                 new utils::ComponentStore(android::V4L2ComponentStore::Create()));
+         if (store == nullptr) {
+             ALOGE("Cannot create Codec2's V4L2 IComponentStore service.");
+-        } else if (store->registerAsService("default") != android::OK) {
++        } else if (store->registerAsService("v4l2") != android::OK) {
+             ALOGE("Cannot register Codec2's IComponentStore service.");
+         } else {
+             ALOGI("Codec2's IComponentStore service created.");

--- a/patches-aosp/external/v4l2_codec2/0004-add-properties-to-set-codec-ranks.patch
+++ b/patches-aosp/external/v4l2_codec2/0004-add-properties-to-set-codec-ranks.patch
@@ -1,0 +1,43 @@
+From d1102c667205bc6d30f5b1bb516c1389bc4e2fd9 Mon Sep 17 00:00:00 2001
+From: Konsta <konsta09@gmail.com>
+Date: Fri, 27 Jan 2023 22:21:23 +0200
+Subject: [PATCH] add properties to set codec ranks
+
+Change-Id: Ic55e3a460e768ef86bb53e88df740d5e14ea3e67
+---
+ components/V4L2ComponentStore.cpp | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/components/V4L2ComponentStore.cpp b/components/V4L2ComponentStore.cpp
+index 4004ce5..6e991d3 100644
+--- a/components/V4L2ComponentStore.cpp
++++ b/components/V4L2ComponentStore.cpp
+@@ -5,6 +5,8 @@
+ //#define LOG_NDEBUG 0
+ #define LOG_TAG "V4L2ComponentStore"
+ 
++#include <android-base/properties.h>
++
+ #include <v4l2_codec2/components/V4L2ComponentStore.h>
+ 
+ #include <stdint.h>
+@@ -22,7 +24,8 @@
+ 
+ namespace android {
+ namespace {
+-const uint32_t kComponentRank = 0x80;
++uint32_t kDecoderRank = ::android::base::GetUintProperty("persist.v4l2_codec2.rank.decoder", 0x80u);
++uint32_t kEncoderRank = ::android::base::GetUintProperty("persist.v4l2_codec2.rank.encoder", 0x80u);
+ 
+ std::string getMediaTypeFromComponentName(const std::string& name) {
+     if (name == V4L2ComponentName::kH264Decoder || name == V4L2ComponentName::kH264SecureDecoder ||
+@@ -191,7 +194,8 @@ std::shared_ptr<const C2Component::Traits> V4L2ComponentStore::GetTraits(const C
+     auto traits = std::make_shared<C2Component::Traits>();
+     traits->name = name;
+     traits->domain = C2Component::DOMAIN_VIDEO;
+-    traits->rank = kComponentRank;
++    traits->rank = V4L2ComponentName::isEncoder(name.c_str()) ? kEncoderRank
++                                                              : kDecoderRank;
+     traits->mediaType = getMediaTypeFromComponentName(name);
+     traits->kind = V4L2ComponentName::isEncoder(name.c_str()) ? C2Component::KIND_ENCODER
+                                                               : C2Component::KIND_DECODER;

--- a/patches-aosp/glodroid/configuration/0002-Add-v4l2_codec2-and-ffmpeg_codec2.patch
+++ b/patches-aosp/glodroid/configuration/0002-Add-v4l2_codec2-and-ffmpeg_codec2.patch
@@ -1,0 +1,285 @@
+From d00d0680ec4002927ca0a33605996808e1d9ad18 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20Gapi=C5=84ski?= <mike@gapinski.eu>
+Date: Thu, 6 Apr 2023 14:45:25 +0200
+Subject: [PATCH 1/1] Add v4l2_codec2(h264 encoder) and ffmpeg_codec2(hwaccel
+ h264, h265 + various sw decoders)
+
+---
+ common/base/ueventd.common.rc                 | 12 ++++-
+ .../codecs/android.hardware.media.omx@1.0.xml | 15 +++++++
+ common/codecs/board.mk                        |  9 ++++
+ common/codecs/codec2.vendor.ext.policy        | 20 +++++++++
+ common/codecs/device.mk                       | 45 ++++++++++++++++++-
+ ..._framework_compatibility_matrix_codec2.xml | 20 +++++++++
+ common/codecs/media_codecs.xml                |  6 +++
+ common/codecs/media_codecs_v4l2_c2_video.xml  | 13 ++++++
+ common/codecs/sepolicy/vendor/file_contexts   |  6 +++
+ .../0015-rpi4-hwcodecs-constraints.patch      | 36 +++++++++++++++
+ 10 files changed, 180 insertions(+), 2 deletions(-)
+ create mode 100644 common/codecs/android.hardware.media.omx@1.0.xml
+ create mode 100644 common/codecs/codec2.vendor.ext.policy
+ create mode 100644 common/codecs/device_framework_compatibility_matrix_codec2.xml
+ create mode 100644 common/codecs/media_codecs.xml
+ create mode 100644 common/codecs/media_codecs_v4l2_c2_video.xml
+ create mode 100644 common/codecs/sepolicy/vendor/file_contexts
+ create mode 100644 common/graphics/patches-minigbm/0015-rpi4-hwcodecs-constraints.patch
+
+diff --git a/common/base/ueventd.common.rc b/common/base/ueventd.common.rc
+index ec7c3d0..0964edf 100644
+--- a/common/base/ueventd.common.rc
++++ b/common/base/ueventd.common.rc
+@@ -37,4 +37,14 @@ subsystem usbmisc
+ /sys/devices/system  *                scaling_max_freq 0644    system       system
+ 
+ # USB Gadget HAL v1.2
+-/sys/class/udc*                          current_speed 0644    system       system
+\ No newline at end of file
++/sys/class/udc*                          current_speed 0644    system       system
++
++# V4L2
++/dev/media0                                            0666    media        media
++/dev/media1                                            0666    media        media
++/dev/video10                                           0666    media        media
++/dev/video11                                           0666    media        media
++/dev/video12                                           0660    media        media
++/dev/video18                                           0666    media        media
++/dev/video19                                           0666    media        media
++/dev/video31                                           0666    media        media
+diff --git a/common/codecs/android.hardware.media.omx@1.0.xml b/common/codecs/android.hardware.media.omx@1.0.xml
+new file mode 100644
+index 0000000..191e66b
+--- /dev/null
++++ b/common/codecs/android.hardware.media.omx@1.0.xml
+@@ -0,0 +1,15 @@
++<manifest version="1.0" type="device" target-level="7">
++<hal format="hidl">
++        <name>android.hardware.media.omx</name>
++        <transport>hwbinder</transport>
++        <version>1.0</version>
++        <interface>
++            <name>IOmx</name>
++            <instance>default</instance>
++        </interface>
++        <interface>
++            <name>IOmxStore</name>
++            <instance>default</instance>
++        </interface>
++    </hal>
++</manifest>
+diff --git a/common/codecs/board.mk b/common/codecs/board.mk
+index ab75105..828f5e7 100644
+--- a/common/codecs/board.mk
++++ b/common/codecs/board.mk
+@@ -3,3 +3,12 @@
+ # GloDroid project (https://github.com/GloDroid)
+ #
+ # Copyright (C) 2022 Roman Stratiienko (r.stratiienko@gmail.com)
++
++
++DEVICE_MANIFEST_FILE += \
++    glodroid/configuration/common/codecs/android.hardware.media.omx@1.0.xml \
++
++BOARD_VENDOR_SEPOLICY_DIRS += glodroid/configuration/common/codecs/sepolicy/vendor
++
++DEVICE_FRAMEWORK_COMPATIBILITY_MATRIX_FILE += \
++    glodroid/configuration/common/codecs/device_framework_compatibility_matrix_codec2.xml \
+diff --git a/common/codecs/codec2.vendor.ext.policy b/common/codecs/codec2.vendor.ext.policy
+new file mode 100644
+index 0000000..faaaedc
+--- /dev/null
++++ b/common/codecs/codec2.vendor.ext.policy
+@@ -0,0 +1,20 @@
++# device specific syscalls
++_llseek: 1
++epoll_create1: 1
++epoll_ctl: 1
++epoll_pwait: 1
++eventfd2: 1
++fstat64: 1
++fstatat64: 1
++fstatfs64: 1
++getcwd: 1
++getdents64: 1
++geteuid32: 1
++getuid32: 1
++mmap2: 1
++open: 1
++pselect6: 1
++sched_getaffinity: 1
++statfs64: 1
++sysinfo: 1
++ugetrlimit: 1
+diff --git a/common/codecs/device.mk b/common/codecs/device.mk
+index e04adfa..9dae8ba 100644
+--- a/common/codecs/device.mk
++++ b/common/codecs/device.mk
+@@ -13,7 +13,8 @@ PRODUCT_VENDOR_PROPERTIES += \
+ 
+ # Copy media codecs config file
+ PRODUCT_COPY_FILES += \
+-    frameworks/av/media/libstagefright/data/media_codecs_google_c2.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_codecs.xml \
++    $(LOCAL_PATH)/media_codecs.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_codecs.xml \
++    $(LOCAL_PATH)/media_codecs_v4l2_c2_video.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_codecs_v4l2_c2_video.xml \
+     frameworks/av/media/libstagefright/data/media_codecs_google_c2_video.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_codecs_google_c2_video.xml \
+     frameworks/av/media/libstagefright/data/media_codecs_google_c2_audio.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_codecs_google_c2_audio.xml \
+     $(LOCAL_PATH)/media_profiles_V1_0.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_profiles_V1_0.xml \
+@@ -22,3 +23,45 @@ PRODUCT_COPY_FILES += \
+ PRODUCT_COPY_FILES += \
+     $(LOCAL_PATH)/mediaswcodec.policy:$(TARGET_COPY_OUT_VENDOR)/etc/seccomp_policy/mediaswcodec.policy \
+     $(LOCAL_PATH)/mediacodec.policy:$(TARGET_COPY_OUT_VENDOR)/etc/seccomp_policy/mediacodec.policy \
++    $(LOCAL_PATH)/codec2.vendor.ext.policy:$(TARGET_COPY_OUT_VENDOR)/etc/seccomp_policy/codec2.vendor.ext.policy \
++
++# FFmpeg codec2
++PRODUCT_PACKAGES += \
++    android.hardware.media.c2@1.2-service-ffmpeg
++
++PRODUCT_VENDOR_PROPERTIES += \
++    persist.ffmpeg_codec2.v4l2.h264=true \
++    persist.ffmpeg_codec2.v4l2.h265=true \
++    persist.ffmpeg_codec2.rank.audio=16 \
++    persist.ffmpeg_codec2.rank.video=128 \
++
++# V4L2 codec2
++PRODUCT_PACKAGES += \
++    android.hardware.media.c2@1.0-service-v4l2 \
++    libv4l2_codec2_vendor_allocator            \
++    libc2plugin_store                          \
++
++PRODUCT_SOONG_NAMESPACES += external/v4l2_codec2
++
++PRODUCT_PROPERTY_OVERRIDES += \
++    persist.v4l2_codec2.rank.decoder=256 \
++    persist.v4l2_codec2.rank.encoder=128 \
++    ro.vendor.v4l2_codec2.decode_concurrent_instances=8 \
++    ro.vendor.v4l2_codec2.encode_concurrent_instances=8 \
++
++# Codec2.0 poolMask:
++#   ION(16)
++#   GRALLOC(17)
++#   BUFFERQUEUE(18)
++#   BLOB(19)
++#   V4L2_BUFFERQUEUE(20)
++#   V4L2_BUFFERPOOL(21)
++#   SECURE_LINEAR(22)
++#   SECURE_GRAPHIC(23)
++#
++# For linear buffer allocation:
++#   If ION is chosen, then the mask should be 0xf50000
++#   If GRALLOC is chosen, then the mask should be 0xf60000
++#   If BLOB is chosen, then the mask should be 0xfc0000
++PRODUCT_PROPERTY_OVERRIDES += \
++    debug.stagefright.c2-poolmask=0x0c0000 \
+diff --git a/common/codecs/device_framework_compatibility_matrix_codec2.xml b/common/codecs/device_framework_compatibility_matrix_codec2.xml
+new file mode 100644
+index 0000000..95005fb
+--- /dev/null
++++ b/common/codecs/device_framework_compatibility_matrix_codec2.xml
+@@ -0,0 +1,20 @@
++<compatibility-matrix version="1.0" type="framework">
++    <hal format="hidl">
++        <name>android.hardware.media.c2</name>
++        <transport>hwbinder</transport>
++        <version>1.2</version>
++        <interface>
++            <name>IComponentStore</name>
++            <instance>ffmpeg</instance>
++        </interface>
++    </hal>
++    <hal format="hidl">
++        <name>android.hardware.media.c2</name>
++        <transport>hwbinder</transport>
++        <version>1.0</version>
++        <interface>
++            <name>IComponentStore</name>
++            <instance>v4l2</instance>
++        </interface>
++    </hal>
++</compatibility-matrix>
+diff --git a/common/codecs/media_codecs.xml b/common/codecs/media_codecs.xml
+new file mode 100644
+index 0000000..0db699e
+--- /dev/null
++++ b/common/codecs/media_codecs.xml
+@@ -0,0 +1,6 @@
++<MediaCodecs>
++    <Include href="media_codecs_ffmpeg_c2.xml" />
++    <Include href="media_codecs_v4l2_c2_video.xml" />
++    <Include href="media_codecs_google_c2_audio.xml" />
++    <Include href="media_codecs_google_c2_video.xml" />
++</MediaCodecs>
+diff --git a/common/codecs/media_codecs_v4l2_c2_video.xml b/common/codecs/media_codecs_v4l2_c2_video.xml
+new file mode 100644
+index 0000000..851bc5a
+--- /dev/null
++++ b/common/codecs/media_codecs_v4l2_c2_video.xml
+@@ -0,0 +1,13 @@
++<Included>
++   <Encoders>
++       <MediaCodec name="c2.v4l2.avc.encoder" type="video/avc">
++           <Limit name="size" min="32x32" max="4096x4096" />
++           <Limit name="alignment" value="2x2" />
++           <Limit name="block-size" value="32x32" />
++           <Limit name="blocks-per-second" range="1-983040" />
++           <Limit name="bitrate" range="1-40000000" />
++           <Limit name="concurrent-instances" max="8" />
++           <Limit name="performance-point-1280x720" range="30-30" />
++       </MediaCodec>
++   </Encoders>
++</Included>
+diff --git a/common/codecs/sepolicy/vendor/file_contexts b/common/codecs/sepolicy/vendor/file_contexts
+new file mode 100644
+index 0000000..6ebe142
+--- /dev/null
++++ b/common/codecs/sepolicy/vendor/file_contexts
+@@ -0,0 +1,6 @@
++# V4L2 codec2
++/vendor/bin/hw/android\.hardware\.media\.c2@1\.0-service-v4l2(.*)?              u:object_r:mediacodec_exec:s0
++/vendor/lib(64)?/libc2plugin_store\.so						u:object_r:same_process_hal_file:s0
++
++# Ffmpeg codec2
++/vendor/bin/hw/android\.hardware\.media\.c2@1\.2-service-ffmpeg(.*)?		u:object_r:mediacodec_exec:s0
+diff --git a/common/graphics/patches-minigbm/0015-rpi4-hwcodecs-constraints.patch b/common/graphics/patches-minigbm/0015-rpi4-hwcodecs-constraints.patch
+new file mode 100644
+index 0000000..02838f5
+--- /dev/null
++++ b/common/graphics/patches-minigbm/0015-rpi4-hwcodecs-constraints.patch
+@@ -0,0 +1,36 @@
++From c4571581b8c1dc2971413106f7eab26be693fd3c Mon Sep 17 00:00:00 2001
++From: Konsta <konsta09@gmail.com>
++Date: Sat, 7 Jan 2023 19:17:11 +0200
++Subject: [PATCH] gbm_mesa: add constraints for hardware video decoder &
++ encoder
++
++Change-Id: I41d2987b30f7a54b481cabb8be8ddab5c68eff63
++---
++ gbm_mesa_driver/gbm_mesa_internals.cpp | 14 ++++++++++++++
++ 1 file changed, 14 insertions(+)
++
++diff --git a/gbm_mesa_driver/gbm_mesa_internals.cpp b/gbm_mesa_driver/gbm_mesa_internals.cpp
++index 918742a..1773825 100644
++--- a/gbm_mesa_driver/gbm_mesa_internals.cpp
+++++ b/gbm_mesa_driver/gbm_mesa_internals.cpp
++@@ -382,6 +382,20 @@ int gbm_mesa_bo_create(struct bo *bo, uint32_t width, uint32_t height, uint32_t
++ 		size_align = 4096;
++ 	}
++ 
+++	/* RPI4 hwcodecs */
+++	if (use_flags & (BO_USE_HW_VIDEO_DECODER | BO_USE_HW_VIDEO_ENCODER)) {
+++		scanout_strong = true;
+++		alloc_args.use_scanout = true;
+++		alloc_args.width = ALIGN(alloc_args.width, 32);
+++		size_align = 4096;
+++	}
+++
+++	/* Allocate blobs in CMA */
+++	if (format == DRM_FORMAT_R8) {
+++		scanout_strong = true;
+++		alloc_args.use_scanout = true;
+++	}
+++
++ 	if (alloc_args.drm_format == 0) {
++ 		/* Always use linear for spoofed format allocations. */
++ 		drv_bo_from_format(bo, alloc_args.width, alloc_args.height, format);
+-- 
+2.34.1
+


### PR DESCRIPTION
v4l2_codec2 provides hardware accelerated  h264 encoding
ffmpeg_codec2 provides hardware accelerated encoding for h264 and h265. Various other formats via software decoding

TODO: switch to mainline ffmpeg via aospext with patches from Jernej, fork ffmpeg_codec2 from raspberry-vanilla