### PR TITLE
Increase super size to ensure device updateability

### DIFF
--- a/patches-aosp/glodroid/configuration/0008-u-boot-Expand-userdata-partition.patch
+++ b/patches-aosp/glodroid/configuration/0008-u-boot-Expand-userdata-partition.patch
@@ -7,8 +7,8 @@ Subject: [PATCH 1/1] u-boot: Expand userdata partition. Fixes unallocated
 ---
  platform/common/uboot.config  |  1 +
  platform/tools/gensdimg.sh    |  4 ++--
- platform/uboot/bootscript.cpp | 21 +++++++++++++++++++++
- 3 files changed, 24 insertions(+), 2 deletions(-)
+ platform/uboot/bootscript.cpp | 19 +++++++++++++++++++
+ 3 files changed, 22 insertions(+), 2 deletions(-)
 
 diff --git a/platform/common/uboot.config b/platform/common/uboot.config
 index 629392f..13e1cc3 100644
@@ -67,8 +67,6 @@ index 0c04f52..c25d207 100644
 +    setexpr final_layout gsub "name=userdata,start=[^,]*,size=[^,]*,uuid" "name=userdata,start=[^,]*,size=-,uuid" ${expanded_layout}
 +    gpt write mmc ${mmc_bootdev} ${final_layout}
 +    echo "The userdata partition has been expanded.";
-+  else
-+    echo "The userdata_placeholder partition does not exist. No action required.";
 +  fi;
 +FUNC_END()
 +

--- a/patches-aosp/glodroid/configuration/0008-u-boot-Expand-userdata-partition.patch
+++ b/patches-aosp/glodroid/configuration/0008-u-boot-Expand-userdata-partition.patch
@@ -1,0 +1,83 @@
+From 94e0c41344350a933c6eb01c36fc2ff64b31f695 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20Gapi=C5=84ski?= <mike@gapinski.eu>
+Date: Fri, 7 Apr 2023 17:35:52 +0200
+Subject: [PATCH 1/1] u-boot: Expand userdata partition. Fixes unallocated
+ space issue when single image install method is used
+
+---
+ platform/common/uboot.config  |  1 +
+ platform/tools/gensdimg.sh    |  4 ++--
+ platform/uboot/bootscript.cpp | 21 +++++++++++++++++++++
+ 3 files changed, 24 insertions(+), 2 deletions(-)
+
+diff --git a/platform/common/uboot.config b/platform/common/uboot.config
+index 629392f..13e1cc3 100644
+--- a/platform/common/uboot.config
++++ b/platform/common/uboot.config
+@@ -4,6 +4,7 @@ CONFIG_CMD_BCB=y
+ CONFIG_CMD_ABOOTIMG=y
+ CONFIG_CMD_ADTIMG=y
+ CONFIG_CMD_GPT=y
++CONFIG_CMD_GPT_RENAME=y
+ CONFIG_USB_GADGET=y
+ CONFIG_USB_FUNCTION_FASTBOOT=y
+ CONFIG_CMD_FASTBOOT=y
+diff --git a/platform/tools/gensdimg.sh b/platform/tools/gensdimg.sh
+index 4e1657e..c422d7c 100755
+--- a/platform/tools/gensdimg.sh
++++ b/platform/tools/gensdimg.sh
+@@ -78,7 +78,7 @@ EOF
+ }
+ 
+ gen_sd() {
+-    prepare_disk $(( 1024 * 8 )) # Default size - 8 GB
++    prepare_disk $(( 1024 * 4 )) # Default size - 4 GB
+ 
+     echo "===> Add partitions"
+     add_part       bootloader      bootloader-sd.img
+@@ -96,7 +96,7 @@ gen_sd() {
+     add_empty_part vbmeta_system_b                       $(( 512 * 1024 ))
+     add_part       super           super.img
+     add_empty_part metadata                        $(( 16 * 1024 * 1024 ))
+-    add_empty_part userdata -
++    add_empty_part userdata_placeholder -
+ 
+     if [ "$PLATFORM" = "broadcom" ]; then
+         modify_for_rpi
+diff --git a/platform/uboot/bootscript.cpp b/platform/uboot/bootscript.cpp
+index 0c04f52..c25d207 100644
+--- a/platform/uboot/bootscript.cpp
++++ b/platform/uboot/bootscript.cpp
+@@ -169,8 +169,29 @@ FUNC_BEGIN(bootcmd_block)
+  mmc read \$dtboaddr \$dtbo_start \$dtbo_size
+ FUNC_END()
+ 
++FUNC_BEGIN(rename_and_expand_userdata_placeholder)
++  part number mmc ${mmc_bootdev} userdata_placeholder partition_number
++  if test -n "${partition_number}";
++  then
++    echo "Renaming userdata_placeholder partition to userdata...";
++    gpt read mmc ${mmc_bootdev} current_layout
++    setexpr new_layout gsub "name=userdata_placeholder" "name=userdata" ${current_layout}
++    gpt write mmc ${mmc_bootdev} ${new_layout}
++    echo "The userdata_placeholder partition has been renamed to userdata.";
++
++    echo "Expanding userdata partition to fill the entire drive...";
++    gpt read mmc ${mmc_bootdev} expanded_layout
++    setexpr final_layout gsub "name=userdata,start=[^,]*,size=[^,]*,uuid" "name=userdata,start=[^,]*,size=-,uuid" ${expanded_layout}
++    gpt write mmc ${mmc_bootdev} ${final_layout}
++    echo "The userdata partition has been expanded.";
++  else
++    echo "The userdata_placeholder partition does not exist. No action required.";
++  fi;
++FUNC_END()
++
+ FUNC_BEGIN(bootcmd)
+  run bootcmd_prepare_env ;
++ run rename_and_expand_userdata_placeholder ;
+  run bootcmd_block ;
+  run bootcmd_start ;
+ FUNC_END()
+-- 
+2.34.1
+

--- a/patches-aosp/glodroid/configuration/0009-Increase-super-size-to-ensure-device-updateability.patch
+++ b/patches-aosp/glodroid/configuration/0009-Increase-super-size-to-ensure-device-updateability.patch
@@ -1,0 +1,55 @@
+From 618cd2bb8e1961b25142b0c19132899dbdaf8379 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20Gapi=C5=84ski?= <mike@gapinski.eu>
+Date: Sat, 8 Apr 2023 18:07:22 +0200
+Subject: [PATCH 1/1] Increase super size to ensure device updateability
+
+---
+ common/base/board.mk          | 4 ++--
+ platform/tools/gensdimg.sh    | 2 +-
+ platform/uboot/bootscript.cpp | 2 +-
+ 3 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/common/base/board.mk b/common/base/board.mk
+index b73abe5..e4b62b8 100644
+--- a/common/base/board.mk
++++ b/common/base/board.mk
+@@ -101,8 +101,8 @@ BOARD_BUILD_SYSTEM_ROOT_IMAGE := false
+ 
+ BOARD_EXT4_SHARE_DUP_BLOCKS := true
+ 
+-# Dynamic partition 1800 MiB
+-BOARD_SUPER_PARTITION_SIZE := $(shell echo $$(( 2000 * 1024 * 1024 )))
++# Dynamic partition 7500 MiB
++BOARD_SUPER_PARTITION_SIZE := $(shell echo $$(( 7500 * 1024 * 1024 )))
+ BOARD_BUILD_SUPER_IMAGE_BY_DEFAULT := true
+ BOARD_SUPER_PARTITION_GROUPS := glodroid_dynamic_partitions
+ BOARD_GLODROID_DYNAMIC_PARTITIONS_SIZE := $(shell echo $$(( $(BOARD_SUPER_PARTITION_SIZE) - (10 * 1024 * 1024) )))
+diff --git a/platform/tools/gensdimg.sh b/platform/tools/gensdimg.sh
+index c422d7c..1b954db 100755
+--- a/platform/tools/gensdimg.sh
++++ b/platform/tools/gensdimg.sh
+@@ -78,7 +78,7 @@ EOF
+ }
+ 
+ gen_sd() {
+-    prepare_disk $(( 1024 * 4 )) # Default size - 4 GB
++    prepare_disk $(( 1024 * 10 )) # Default size - 10 GB
+ 
+     echo "===> Add partitions"
+     add_part       bootloader      bootloader-sd.img
+diff --git a/platform/uboot/bootscript.cpp b/platform/uboot/bootscript.cpp
+index c25d207..dafd74e 100644
+--- a/platform/uboot/bootscript.cpp
++++ b/platform/uboot/bootscript.cpp
+@@ -39,7 +39,7 @@ EXTENV(partitions, ";name=vbmeta_a,size=512K,uuid=\${uuid_gpt_vbmeta_a}")
+ EXTENV(partitions, ";name=vbmeta_b,size=512K,uuid=\${uuid_gpt_vbmeta_b}")
+ EXTENV(partitions, ";name=vbmeta_system_a,size=512K,uuid=\${uuid_gpt_vbmeta_system_a}")
+ EXTENV(partitions, ";name=vbmeta_system_b,size=512K,uuid=\${uuid_gpt_vbmeta_system_b}")
+-EXTENV(partitions, ";name=super,size=2000M,uuid=\${uuid_gpt_super}")
++EXTENV(partitions, ";name=super,size=7500M,uuid=\${uuid_gpt_super}")
+ EXTENV(partitions, ";name=metadata,size=16M,uuid=\${uuid_gpt_metadata}")
+ EXTENV(partitions, ";name=userdata,size=-,uuid=\${uuid_gpt_userdata}")
+ 
+-- 
+2.34.1
+

--- a/patches-aosp/glodroid/configuration/0009-Increase-super-size-to-ensure-device-updateability.patch
+++ b/patches-aosp/glodroid/configuration/0009-Increase-super-size-to-ensure-device-updateability.patch
@@ -1,7 +1,7 @@
 From 618cd2bb8e1961b25142b0c19132899dbdaf8379 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Micha=C5=82=20Gapi=C5=84ski?= <mike@gapinski.eu>
 Date: Sat, 8 Apr 2023 18:07:22 +0200
-Subject: [PATCH 1/1] Increase super size to ensure device updateability
+Subject: [PATCH 1/1] RPI4: Increase super size to ensure device updateability
 
 ---
  common/base/board.mk          | 4 ++--

--- a/patches-aosp/glodroid/configuration/0010-Compress-the-sdcard-image.patch
+++ b/patches-aosp/glodroid/configuration/0010-Compress-the-sdcard-image.patch
@@ -1,0 +1,25 @@
+From dbc50df17bd18d5f69df3ece60915846eb839ad8 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20Gapi=C5=84ski?= <mike@gapinski.eu>
+Date: Sat, 8 Apr 2023 19:29:31 +0200
+Subject: [PATCH] Compress the sdcard image
+
+---
+ platform/tools/gensdimg.sh | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/platform/tools/gensdimg.sh b/platform/tools/gensdimg.sh
+index 1b954db..2464a95 100755
+--- a/platform/tools/gensdimg.sh
++++ b/platform/tools/gensdimg.sh
+@@ -101,6 +101,8 @@ gen_sd() {
+     if [ "$PLATFORM" = "broadcom" ]; then
+         modify_for_rpi
+     fi
++
++    tar -cvzf $SDIMG.tar.gz $SDIMG
+ }
+ 
+ gen_deploy() {
+-- 
+2.34.1
+


### PR DESCRIPTION
Current super size does not take consider OTA updates. When the update is installing the snapshots for the new slot are stored on /data and the user needs to have a certain amount of free space on the partition to install the update. This is not the recommended way of handling OTA according to https://source.android.com/docs/core/ota/dynamic_partitions/how_to_size_super?hl=en

I've taken 2.5GB as a base for my calculations, super size with slim gapps is 2455498752 for me. 7.5GB enables OTA without having to rely on /data for snapshots with room to grow:
  
FinalDessertSize = FactorySize + (FactorySize * ExpectedGrowth)
Super = Max(FinalDessertUpdate, FinalDessertSize * 2 - AllowedUserdataUse)

ExpectedGrowth=0.5; AllowedUserdataUse=0 

7.5GB is conservative, GS101/201 use 8.5GB now but I doubt anyone uses full gapps on GloDroid.

I also compress the sdcard img to make it more manageable:

-rw-rw-r--  1 mgapinski mgapinski 10737418240 kwi  8 18:58 sdcard.img
-rw-rw-r--  1 mgapinski mgapinski  1167841252 kwi  8 19:01 sdcard.img.tar.gz

I know it's a huge bump in image size but let's face it, people should not use small and slow sdcards to begin with
