### PR TITLE
Fix corrupt patch

### DIFF
--- a/patches-aosp/glodroid/configuration/0008-u-boot-Expand-userdata-partition.patch
+++ b/patches-aosp/glodroid/configuration/0008-u-boot-Expand-userdata-partition.patch
@@ -1,4 +1,4 @@
-From 94e0c41344350a933c6eb01c36fc2ff64b31f695 Mon Sep 17 00:00:00 2001
+From 9fef93e3617bc4924283559254087a0629df815a Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Micha=C5=82=20Gapi=C5=84ski?= <mike@gapinski.eu>
 Date: Fri, 7 Apr 2023 17:35:52 +0200
 Subject: [PATCH 1/1] u-boot: Expand userdata partition. Fixes unallocated
@@ -23,7 +23,7 @@ index 629392f..13e1cc3 100644
  CONFIG_USB_FUNCTION_FASTBOOT=y
  CONFIG_CMD_FASTBOOT=y
 diff --git a/platform/tools/gensdimg.sh b/platform/tools/gensdimg.sh
-index 4e1657e..c422d7c 100755
+index 4e1657e..5062c6b 100755
 --- a/platform/tools/gensdimg.sh
 +++ b/platform/tools/gensdimg.sh
 @@ -78,7 +78,7 @@ EOF
@@ -45,10 +45,10 @@ index 4e1657e..c422d7c 100755
      if [ "$PLATFORM" = "broadcom" ]; then
          modify_for_rpi
 diff --git a/platform/uboot/bootscript.cpp b/platform/uboot/bootscript.cpp
-index 0c04f52..c25d207 100644
+index 0c04f52..de60224 100644
 --- a/platform/uboot/bootscript.cpp
 +++ b/platform/uboot/bootscript.cpp
-@@ -169,8 +169,29 @@ FUNC_BEGIN(bootcmd_block)
+@@ -169,8 +169,27 @@ FUNC_BEGIN(bootcmd_block)
   mmc read \$dtboaddr \$dtbo_start \$dtbo_size
  FUNC_END()
  

--- a/patches-aosp/glodroid/configuration/0008-u-boot-Expand-userdata-partition.patch
+++ b/patches-aosp/glodroid/configuration/0008-u-boot-Expand-userdata-partition.patch
@@ -7,8 +7,8 @@ Subject: [PATCH 1/1] u-boot: Expand userdata partition. Fixes unallocated
 ---
  platform/common/uboot.config  |  1 +
  platform/tools/gensdimg.sh    |  4 ++--
- platform/uboot/bootscript.cpp | 21 +++++++++++++++++++++
- 3 files changed, 24 insertions(+), 2 deletions(-)
+ platform/uboot/bootscript.cpp | 19 +++++++++++++++++++
+ 3 files changed, 22 insertions(+), 2 deletions(-)
 
 diff --git a/platform/common/uboot.config b/platform/common/uboot.config
 index 629392f..13e1cc3 100644
@@ -67,8 +67,6 @@ index 0c04f52..c25d207 100644
 +    setexpr final_layout gsub "name=userdata,start=[^,]*,size=[^,]*,uuid" "name=userdata,start=[^,]*,size=-,uuid" ${expanded_layout}
 +    gpt write mmc ${mmc_bootdev} ${final_layout}
 +    echo "The userdata partition has been expanded.";
-+  else
-+    echo "The userdata_placeholder partition does not exist. No action required.";
 +  fi;
 +FUNC_END()
 +

--- a/patches-aosp/glodroid/configuration/0008-u-boot-Expand-userdata-partition.patch
+++ b/patches-aosp/glodroid/configuration/0008-u-boot-Expand-userdata-partition.patch
@@ -1,0 +1,83 @@
+From 94e0c41344350a933c6eb01c36fc2ff64b31f695 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20Gapi=C5=84ski?= <mike@gapinski.eu>
+Date: Fri, 7 Apr 2023 17:35:52 +0200
+Subject: [PATCH 1/1] u-boot: Expand userdata partition. Fixes unallocated
+ space issue when single image install method is used
+
+---
+ platform/common/uboot.config  |  1 +
+ platform/tools/gensdimg.sh    |  4 ++--
+ platform/uboot/bootscript.cpp | 21 +++++++++++++++++++++
+ 3 files changed, 24 insertions(+), 2 deletions(-)
+
+diff --git a/platform/common/uboot.config b/platform/common/uboot.config
+index 629392f..13e1cc3 100644
+--- a/platform/common/uboot.config
++++ b/platform/common/uboot.config
+@@ -4,6 +4,7 @@ CONFIG_CMD_BCB=y
+ CONFIG_CMD_ABOOTIMG=y
+ CONFIG_CMD_ADTIMG=y
+ CONFIG_CMD_GPT=y
++CONFIG_CMD_GPT_RENAME=y
+ CONFIG_USB_GADGET=y
+ CONFIG_USB_FUNCTION_FASTBOOT=y
+ CONFIG_CMD_FASTBOOT=y
+diff --git a/platform/tools/gensdimg.sh b/platform/tools/gensdimg.sh
+index 4e1657e..c422d7c 100755
+--- a/platform/tools/gensdimg.sh
++++ b/platform/tools/gensdimg.sh
+@@ -78,7 +78,7 @@ EOF
+ }
+ 
+ gen_sd() {
+-    prepare_disk $(( 1024 * 8 )) # Default size - 8 GB
++    prepare_disk $(( 1024 * 4 )) # Default size - 4 GB
+ 
+     echo "===> Add partitions"
+     add_part       bootloader      bootloader-sd.img
+@@ -96,7 +96,7 @@ gen_sd() {
+     add_empty_part vbmeta_system_b                       $(( 512 * 1024 ))
+     add_part       super           super.img
+     add_empty_part metadata                        $(( 16 * 1024 * 1024 ))
+-    add_empty_part userdata -
++    add_empty_part userdata_placeholder -
+ 
+     if [ "$PLATFORM" = "broadcom" ]; then
+         modify_for_rpi
+diff --git a/platform/uboot/bootscript.cpp b/platform/uboot/bootscript.cpp
+index 0c04f52..c25d207 100644
+--- a/platform/uboot/bootscript.cpp
++++ b/platform/uboot/bootscript.cpp
+@@ -169,8 +169,29 @@ FUNC_BEGIN(bootcmd_block)
+  mmc read \$dtboaddr \$dtbo_start \$dtbo_size
+ FUNC_END()
+ 
++FUNC_BEGIN(rename_and_expand_userdata_placeholder)
++  part number mmc ${mmc_bootdev} userdata_placeholder partition_number
++  if test -n "${partition_number}";
++  then
++    echo "Renaming userdata_placeholder partition to userdata...";
++    gpt read mmc ${mmc_bootdev} current_layout
++    setexpr new_layout gsub "name=userdata_placeholder" "name=userdata" ${current_layout}
++    gpt write mmc ${mmc_bootdev} ${new_layout}
++    echo "The userdata_placeholder partition has been renamed to userdata.";
++
++    echo "Expanding userdata partition to fill the entire drive...";
++    gpt read mmc ${mmc_bootdev} expanded_layout
++    setexpr final_layout gsub "name=userdata,start=[^,]*,size=[^,]*,uuid" "name=userdata,start=[^,]*,size=-,uuid" ${expanded_layout}
++    gpt write mmc ${mmc_bootdev} ${final_layout}
++    echo "The userdata partition has been expanded.";
++  else
++    echo "The userdata_placeholder partition does not exist. No action required.";
++  fi;
++FUNC_END()
++
+ FUNC_BEGIN(bootcmd)
+  run bootcmd_prepare_env ;
++ run rename_and_expand_userdata_placeholder ;
+  run bootcmd_block ;
+  run bootcmd_start ;
+ FUNC_END()
+-- 
+2.34.1
+


### PR DESCRIPTION
Applying: base: Don't use updatable apexes
Applying: bootscript: Disable uart logging
Applying: Disable AVB
Applying: bootscript: Use ab_test command
Applying: common: Add OTA-related packages
Applying: Fixes for OTA updates
Applying: u-boot: Expand userdata partition. Fixes unallocated space issue when single image install method is used
error: corrupt patch at line 74
Patch failed at 0009 u-boot: Expand userdata partition. Fixes unallocated space issue when single image install method is used

The line offset was wrong after I removed the echo...