### PR TITLE
Add Bluetooth profile properties

### DIFF
--- a/aosptree/vendor/devices-community/gd_rpi4/device.mk
+++ b/aosptree/vendor/devices-community/gd_rpi4/device.mk
@@ -66,3 +66,29 @@ PRODUCT_VENDOR_PROPERTIES +=    \
 
 # It is the only way to set ro.hwui.use_vulkan=true
 #TARGET_USES_VULKAN = true
+
+# Bluetooth
+PRODUCT_VENDOR_PROPERTIES +=    \
+    bluetooth.device.class_of_device=90,2,12 \
+    bluetooth.profile.asha.central.enabled=true \
+    bluetooth.profile.a2dp.source.enabled=true \
+    bluetooth.profile.avrcp.target.enabled=true \
+    bluetooth.profile.bap.broadcast.assist.enabled=true \
+    bluetooth.profile.bap.unicast.client.enabled=true \
+    bluetooth.profile.bas.client.enabled=true \
+    bluetooth.profile.csip.set_coordinator.enabled=true \
+    bluetooth.profile.gatt.enabled=true \
+    bluetooth.profile.hap.client.enabled=true \
+    bluetooth.profile.hfp.ag.enabled=true \
+    bluetooth.profile.hid.device.enabled=true \
+    bluetooth.profile.hid.host.enabled=true \
+    bluetooth.profile.map.server.enabled=true \
+    bluetooth.profile.mcp.server.enabled=true \
+    bluetooth.profile.opp.enabled=true \
+    bluetooth.profile.pan.nap.enabled=true \
+    bluetooth.profile.pan.panu.enabled=true \
+    bluetooth.profile.pbap.server.enabled=true \
+    bluetooth.profile.sap.server.enabled=true \
+    bluetooth.profile.ccp.server.enabled=true \
+    bluetooth.profile.vcp.controller.enabled=true \
+    persist.bluetooth.a2dp_aac.vbr_supported=true


### PR DESCRIPTION
Bluetooth profiles are required to enable certain types of devices(BT game controllers etc). 