### PR TITLE
HwcDisplayConfigs: switch headless display to 30Hz

### DIFF
--- a/patches-aosp/glodroid/vendor/drm_hwcomposer/0001-HwcDisplayConfigs-switch-headless-display-to-30Hz.patch
+++ b/patches-aosp/glodroid/vendor/drm_hwcomposer/0001-HwcDisplayConfigs-switch-headless-display-to-30Hz.patch
@@ -1,0 +1,26 @@
+From 8b2bfba2d48a2ec4dd480dd59a38b3dc989fe361 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20Gapi=C5=84ski?= <mike@gapinski.eu>
+Date: Mon, 17 Apr 2023 15:24:25 +0200
+Subject: [PATCH 1/1] HwcDisplayConfigs: switch headless display to 30Hz
+
+Change-Id: Ifce78324930929ed84d539495cc8aa051c77e496
+---
+ hwc2_device/HwcDisplayConfigs.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/hwc2_device/HwcDisplayConfigs.cpp b/hwc2_device/HwcDisplayConfigs.cpp
+index 9727989..d281cdb 100644
+--- a/hwc2_device/HwcDisplayConfigs.cpp
++++ b/hwc2_device/HwcDisplayConfigs.cpp
+@@ -27,7 +27,7 @@ constexpr uint32_t kHeadlessModeDisplayWidthMm = 163;
+ constexpr uint32_t kHeadlessModeDisplayHeightMm = 122;
+ constexpr uint32_t kHeadlessModeDisplayWidthPx = 1024;
+ constexpr uint32_t kHeadlessModeDisplayHeightPx = 768;
+-constexpr uint32_t kHeadlessModeDisplayVRefresh = 60;
++constexpr uint32_t kHeadlessModeDisplayVRefresh = 30;
+ 
+ namespace android {
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
When headless display mode is used in drm_hwcomposer we use scrcpy(with software encoder or v4l2 hardware one) or other capture methods to interact with the device

The Pi can't keep up with 60Hz encoding for higher resolutions and even in 1024x768 switching to 30Hz significantly reduces the CPU load when VirtualDisplay is utilized for capture.

With this patch the board is able to play video on virtual displays smoothly without putting too much load on the CPU.

I used to "control the framerate" of my capture software by ignoring frames and not sending them to the encoder, this also worked but the resources were already wasted before since the frames they were already composed without being consumed