### PR TITLE
Update to Android 13 QPR3 (android-platform-13.0.0_r8)

### DIFF
--- a/unfold_aosp.sh
+++ b/unfold_aosp.sh
@@ -4,7 +4,7 @@ LOCAL_PATH=$(pwd)
 
 echo Init repo tree using AOSP manifest
 pushd aosptree
-repo init -u https://android.googlesource.com/platform/manifest -b refs/tags/android-13.0.0_r43
+repo init -u https://android.googlesource.com/platform/manifest -b refs/tags/android-platform-13.0.0_r8
 cd .repo/manifests
 mv default.xml aosp.xml
 cp ${LOCAL_PATH}/manifests/glodroid.xml glodroid.xml


### PR DESCRIPTION
I've decided to switch to platform tags instead of Pixel releases. 

The "latest" or "highest number" Pixel tag might be based on an older release in some cases. The Android Platform tags are more consistent/predictable. They are published quicker too.