### PR TITLE
Enable Vulkan backend for SKIA/HWUI

### DIFF
--- a/aosptree/vendor/devices-community/gd_rpi4/device.mk
+++ b/aosptree/vendor/devices-community/gd_rpi4/device.mk
@@ -64,8 +64,8 @@ PRODUCT_COPY_FILES += \
 PRODUCT_VENDOR_PROPERTIES +=    \
     ro.hardware.vulkan=broadcom \
 
-# It is the only way to set ro.hwui.use_vulkan=true
-#TARGET_USES_VULKAN = true
+# Enable Vulkan backend for SKIA/HWUI
+TARGET_USES_VULKAN = true
 
 # Bluetooth
 PRODUCT_VENDOR_PROPERTIES +=    \

--- a/manifests/glodroid.xml
+++ b/manifests/glodroid.xml
@@ -20,7 +20,7 @@
   <!-- gpu+display components (vendor) -->
   <project path="glodroid/vendor/minigbm"         remote="aosp" name="platform/external/minigbm"        groups="glodroid" revision="84b3a09ef0e620c1b2ec19c7626c327e68a847bc" />
   <project path="glodroid/vendor/drm_hwcomposer"  remote="aosp" name="platform/external/drm_hwcomposer" groups="glodroid" revision="5de61b5e4fbf43b78b605dab68465aa6722930c4" />
-  <project path="glodroid/vendor/mesa3d"          remote="aosp" name="platform/external/mesa3d"         groups="glodroid" revision="refs/tags/upstream-mesa-23.1.5" />
+  <project path="glodroid/vendor/mesa3d"          remote="aosp" name="platform/external/mesa3d"         groups="glodroid" revision="f88338f80127d8bbbb49269e2399fd9e7e460c5c" />
 
   <!-- camera components (vendor) -->
   <project path="glodroid/vendor/libcamera"                     remote="libcamera" name="libcamera.git"      groups="glodroid" revision="960d0c1e19feaf310321c906e14bd5410c6be629" />


### PR DESCRIPTION
Mesa3D/v3dv AHB extension support has been landed [1]. It's time to migrate the UI to use Vulkan API.

[1]: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/14195