### PR TITLE
Fix ancient meson

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ sudo apt-get install -y git-core gnupg flex bison build-essential zip curl zlib1
 
 - Install additional packages
 ```bash
-sudo apt-get install -y swig libssl-dev flex bison device-tree-compiler mtools git gettext libncurses5 libgmp-dev libmpc-dev cpio rsync dosfstools kmod gdisk lz4 meson cmake libglib2.0-dev git-lfs libgnutls28-dev
+sudo apt-get install -y swig libssl-dev flex bison device-tree-compiler mtools git gettext libncurses5 libgmp-dev libmpc-dev cpio rsync dosfstools kmod gdisk lz4 cmake libglib2.0-dev git-lfs libgnutls28-dev
 ```
 
 <br/>
@@ -60,7 +60,7 @@ sudo apt-get install -y swig libssl-dev flex bison device-tree-compiler mtools g
 - Install additional packages (for building mesa3d, libcamera, and other meson-based components)
 ```bash
 sudo apt-get install -y python3-pip pkg-config python3-dev ninja-build
-sudo pip3 install mako jinja2 ply pyyaml pyelftools
+sudo pip3 install mako jinja2 ply pyyaml pyelftools meson
 ```
 
 - Install the `repo` tool


### PR DESCRIPTION
Fix build error:
meson.build:21:0: ERROR: Meson version is 0.61.2 but project requires >= 1.1.0

Use pip3 meson installation instead apt

Used build env:
Distributor ID: Ubuntu
Description:    Ubuntu 22.04.4 LTS
Release:        22.04
Codename:       jammy