### PR TITLE
Fix build on the latest Ubuntu

### DIFF
--- a/patches-aosp/glodroid/vendor/ffmpeg/0122-doc-html-support-texinfo-7.0.patch
+++ b/patches-aosp/glodroid/vendor/ffmpeg/0122-doc-html-support-texinfo-7.0.patch
@@ -1,0 +1,218 @@
+From 6b5278489f0c7d7c1b34022bbd729bac037c944f Mon Sep 17 00:00:00 2001
+From: Frank Plowman <post@frankplowman.com>
+Date: Wed, 8 Nov 2023 07:55:18 +0000
+Subject: [PATCH 121/121] doc/html: support texinfo 7.0
+
+Resolves trac ticket #10636 (http://trac.ffmpeg.org/ticket/10636).
+
+Texinfo 7.0, released in November 2022, changed the names of various
+functions. Compiling docs with Texinfo 7.0 resulted in warnings and
+improperly formatted documentation. More old names appear to have
+been removed in Texinfo 7.1, released October 2023, which causes docs
+compilation to fail.
+
+This commit addresses the issue by adding logic to switch between the old
+and new function names depending on the Texinfo version. Texinfo 6.8
+produces identical documentation before and after the patch.
+
+CC
+https://www.mail-archive.com/debian-bugs-dist@lists.debian.org/msg1938238.html
+https://bugs.gentoo.org/916104
+
+Signed-off-by: Frank Plowman <post@frankplowman.com>
+---
+ doc/t2h.pm | 106 ++++++++++++++++++++++++++++++++++++++++++-----------
+ 1 file changed, 85 insertions(+), 21 deletions(-)
+
+diff --git a/doc/t2h.pm b/doc/t2h.pm
+index d07d974286..b7485e1f1e 100644
+--- a/doc/t2h.pm
++++ b/doc/t2h.pm
+@@ -20,8 +20,45 @@
+ # License along with FFmpeg; if not, write to the Free Software
+ # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ 
++# Texinfo 7.0 changed the syntax of various functions.
++# Provide a shim for older versions.
++sub ff_set_from_init_file($$) {
++    my $key = shift;
++    my $value = shift;
++    if (exists &{'texinfo_set_from_init_file'}) {
++        texinfo_set_from_init_file($key, $value);
++    } else {
++        set_from_init_file($key, $value);
++    }
++}
++
++sub ff_get_conf($) {
++    my $key = shift;
++    if (exists &{'texinfo_get_conf'}) {
++        texinfo_get_conf($key);
++    } else {
++        get_conf($key);
++    }
++}
++
++sub get_formatting_function($$) {
++    my $obj = shift;
++    my $func = shift;
++
++    my $sub = $obj->can('formatting_function');
++    if ($sub) {
++        return $obj->formatting_function($func);
++    } else {
++        return $obj->{$func};
++    }
++}
++
++# determine texinfo version
++my $program_version_num = version->declare(ff_get_conf('PACKAGE_VERSION'))->numify;
++my $program_version_6_8 = $program_version_num >= 6.008000;
++
+ # no navigation elements
+-set_from_init_file('HEADERS', 0);
++ff_set_from_init_file('HEADERS', 0);
+ 
+ sub ffmpeg_heading_command($$$$$)
+ {
+@@ -55,7 +92,7 @@ sub ffmpeg_heading_command($$$$$)
+         $element = $command->{'parent'};
+     }
+     if ($element) {
+-        $result .= &{$self->{'format_element_header'}}($self, $cmdname,
++        $result .= &{get_formatting_function($self, 'format_element_header')}($self, $cmdname,
+                                                        $command, $element);
+     }
+ 
+@@ -112,7 +149,11 @@ sub ffmpeg_heading_command($$$$$)
+                 $cmdname
+                     = $Texinfo::Common::level_to_structuring_command{$cmdname}->[$heading_level];
+             }
+-            $result .= &{$self->{'format_heading_text'}}(
++            # format_heading_text expects an array of headings for texinfo >= 7.0
++            if ($program_version_num >= 7.000000) {
++                $heading = [$heading];
++            }
++            $result .= &{get_formatting_function($self,'format_heading_text')}(
+                         $self, $cmdname, $heading,
+                         $heading_level +
+                         $self->get_conf('CHAPTER_HEADER_LEVEL') - 1, $command);
+@@ -126,23 +167,19 @@ foreach my $command (keys(%Texinfo::Common::sectioning_commands), 'node') {
+     texinfo_register_command_formatting($command, \&ffmpeg_heading_command);
+ }
+ 
+-# determine if texinfo is at least version 6.8
+-my $program_version_num = version->declare(get_conf('PACKAGE_VERSION'))->numify;
+-my $program_version_6_8 = $program_version_num >= 6.008000;
+-
+ # print the TOC where @contents is used
+ if ($program_version_6_8) {
+-    set_from_init_file('CONTENTS_OUTPUT_LOCATION', 'inline');
++    ff_set_from_init_file('CONTENTS_OUTPUT_LOCATION', 'inline');
+ } else {
+-    set_from_init_file('INLINE_CONTENTS', 1);
++    ff_set_from_init_file('INLINE_CONTENTS', 1);
+ }
+ 
+ # make chapters <h2>
+-set_from_init_file('CHAPTER_HEADER_LEVEL', 2);
++ff_set_from_init_file('CHAPTER_HEADER_LEVEL', 2);
+ 
+ # Do not add <hr>
+-set_from_init_file('DEFAULT_RULE', '');
+-set_from_init_file('BIG_RULE', '');
++ff_set_from_init_file('DEFAULT_RULE', '');
++ff_set_from_init_file('BIG_RULE', '');
+ 
+ # Customized file beginning
+ sub ffmpeg_begin_file($$$)
+@@ -159,7 +196,18 @@ sub ffmpeg_begin_file($$$)
+     my ($title, $description, $encoding, $date, $css_lines,
+         $doctype, $bodytext, $copying_comment, $after_body_open,
+         $extra_head, $program_and_version, $program_homepage,
+-        $program, $generator) = $self->_file_header_informations($command);
++        $program, $generator);
++    if ($program_version_num >= 7.000000) {
++        ($title, $description, $encoding, $date, $css_lines,
++         $doctype, $bodytext, $copying_comment, $after_body_open,
++         $extra_head, $program_and_version, $program_homepage,
++         $program, $generator) = $self->_file_header_information($command);
++    } else {
++        ($title, $description, $encoding, $date, $css_lines,
++         $doctype, $bodytext, $copying_comment, $after_body_open,
++         $extra_head, $program_and_version, $program_homepage,
++         $program, $generator) = $self->_file_header_informations($command);
++    }
+ 
+     my $links = $self->_get_links ($filename, $element);
+ 
+@@ -223,7 +271,7 @@ if ($program_version_6_8) {
+ sub ffmpeg_end_file($)
+ {
+     my $self = shift;
+-    my $program_string = &{$self->{'format_program_string'}}($self);
++    my $program_string = &{get_formatting_function($self,'format_program_string')}($self);
+     my $program_text = <<EOT;
+       <p style="font-size: small;">
+         $program_string
+@@ -244,7 +292,7 @@ if ($program_version_6_8) {
+ 
+ # Dummy title command
+ # Ignore title. Title is handled through ffmpeg_begin_file().
+-set_from_init_file('USE_TITLEPAGE_FOR_TITLE', 1);
++ff_set_from_init_file('USE_TITLEPAGE_FOR_TITLE', 1);
+ sub ffmpeg_title($$$$)
+ {
+     return '';
+@@ -262,8 +310,14 @@ sub ffmpeg_float($$$$$)
+     my $args = shift;
+     my $content = shift;
+ 
+-    my ($caption, $prepended) = Texinfo::Common::float_name_caption($self,
+-                                                                $command);
++    my ($caption, $prepended);
++    if ($program_version_num >= 7.000000) {
++        ($caption, $prepended) = Texinfo::Convert::Converter::float_name_caption($self,
++                                                                                 $command);
++    } else {
++        ($caption, $prepended) = Texinfo::Common::float_name_caption($self,
++                                                                     $command);
++    }
+     my $caption_text = '';
+     my $prepended_text;
+     my $prepended_save = '';
+@@ -335,8 +389,13 @@ sub ffmpeg_float($$$$$)
+             $caption->{'args'}->[0], 'float caption');
+     }
+     if ($prepended_text.$caption_text ne '') {
+-        $prepended_text = $self->_attribute_class('div','float-caption'). '>'
+-                . $prepended_text;
++        if ($program_version_num >= 7.000000) {
++            $prepended_text = $self->html_attribute_class('div',['float-caption']). '>'
++                    . $prepended_text;
++        } else {
++            $prepended_text = $self->_attribute_class('div','float-caption'). '>'
++                    . $prepended_text;
++        }
+         $caption_text .= '</div>';
+     }
+     my $html_class = '';
+@@ -349,8 +408,13 @@ sub ffmpeg_float($$$$$)
+         $prepended_text = '';
+         $caption_text   = '';
+     }
+-    return $self->_attribute_class('div', $html_class). '>' . "\n" .
+-        $prepended_text . $caption_text . $content . '</div>';
++    if ($program_version_num >= 7.000000) {
++        return $self->html_attribute_class('div', [$html_class]). '>' . "\n" .
++            $prepended_text . $caption_text . $content . '</div>';
++    } else {
++        return $self->_attribute_class('div', $html_class). '>' . "\n" .
++            $prepended_text . $caption_text . $content . '</div>';
++    }
+ }
+ 
+ texinfo_register_command_formatting('float',
+-- 
+2.43.0
+


### PR DESCRIPTION
Ffmpeg started to complain about the incompatibility with the new texinfo. Backport mainline ffmpeg patch that fixes it.